### PR TITLE
Upgrade to LTS 7.19/GHC-8.0.1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.21
+resolver: lts-7.19
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/twilio.cabal
+++ b/twilio.cabal
@@ -89,8 +89,8 @@ library
                        old-locale ==1.0.*,
                        scientific ==0.*,
                        text ==1.*,
-                       time ==1.5.*,
-                       transformers ==0.4.*,
+                       time >=1.5 && < 2,
+                       transformers >=0.4.1 && < 0.6,
                        unordered-containers ==0.2.*
 
 test-suite Tests
@@ -102,8 +102,8 @@ test-suite Tests
                        bytestring ==0.10.*,
                        Cabal >=1.16.0,
                        http-client ==0.*,
-                       http-client-tls ==0.2.*,
+                       http-client-tls >=0.2 && < 0.4,
                        network-uri >=2.6,
                        text ==1.*,
-                       transformers ==0.4.*,
+                       transformers >=0.4.1 && < 0.6,
                        twilio


### PR DESCRIPTION
This upgrades `collegevine/twilio-haskell` to `LTS 7.19/GHC-8.0.1`, so that we can upgrade later `collegevine/vines`, and fixes the following error while trying to run the tests:
```
While constructing the build plan, the following exceptions were encountered:

In the dependencies for twilio-0.1.3.1:
    http-client-tls-0.3.3 must match >=0.2.0 && <0.3 (latest applicable is 0.2.4.1)

Plan construction failed.
```
After fixing it, this is the output for the tests run:
```
Tests: Maybe.fromJust: Nothing

Completed 2 action(s).
Test suite failure for package twilio-0.1.3.1
    Tests:  exited with: ExitFailure 1
Logs printed to console
```
I'm not sure how that affects as we were unable to run the tests before the fix